### PR TITLE
fix: 修复判断typeof navigator !== 'undefined'导致的页面崩溃

### DIFF
--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -35,7 +35,7 @@ function getLocale() {
   const { g_langSeparator = '-', g_lang } = window;
   const lang = typeof localStorage !== 'undefined' ? window.localStorage.getItem('umi_locale') : '';
   const browserLang =
-    typeof navigator !== 'undefined' ? navigator.language.split('-').join(g_langSeparator) : '';
+    typeof navigator.language !== 'undefined' ? navigator.language.split('-').join(g_langSeparator) : '';
   return lang || g_lang || browserLang;
 }
 


### PR DESCRIPTION
修复判断代码错误，该错误会导致在IE10上报错。在IE10上navigator.language为undefined
